### PR TITLE
Add GitHub markdown helper to highlight text

### DIFF
--- a/src/__tests__/MarkdownHighlight.test.tsx
+++ b/src/__tests__/MarkdownHighlight.test.tsx
@@ -1,0 +1,60 @@
+import MarkdownHighlight from "@/app/cards/MarkdownHighlight";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+describe("MarkdownHighlight", () => {
+  beforeEach(() => {
+    render(
+      <MarkdownHighlight isVisible={true} id="Highlight" />,
+    );
+  });
+
+  it("renders a title in the card header", () => {
+    const title = screen.getByTestId("card-header");
+
+    expect(title).toBeInTheDocument();
+    expect(title).toBeVisible();
+    expect(title.textContent).toBe("HIGHLIGHT");
+  });
+
+  it("renders the code snippets", () => {
+    const codeSnippets = screen.getAllByTestId("markdown-highlight-code-snippet");
+
+          expect(codeSnippets).toHaveLength(5);
+      codeSnippets.map((snippet, index) => {
+        expect(snippet).toBeInTheDocument();
+        expect(snippet).toBeVisible();
+
+        if (index === 0) expect(snippet.textContent).toMatch(/\[\!NOTE\]/gim);
+
+        if (index === 1) expect(snippet.textContent).toMatch(/\[\!TIP\]/gim);
+        if (index === 2) expect(snippet.textContent).toMatch(/\[\!IMPORTANT\]/gim);
+        if (index === 3) expect(snippet.textContent).toMatch(/\[\!WARNING\]/gim);
+        if (index === 4) expect(snippet.textContent).toMatch(/\[\!CAUTION\]/gim);
+      });
+  });
+
+  it("has a copy button only visible on hover on the code snippet", () => {
+    const codeSnippet = screen.getAllByTestId("markdown-highlight-code-snippet");
+    const copyButton = screen.getAllByTestId("copy-button")[0];
+
+    expect(copyButton.blur()).toBeUndefined();
+
+    fireEvent.mouseOver(codeSnippet[0]);
+    waitFor(() => expect(copyButton).toBeVisible());
+
+    fireEvent.mouseLeave(codeSnippet[0]);
+    waitFor(() => expect(copyButton).toBeUndefined());
+  });
+});
+
+ describe("MarkdownHighlight isVisible is false", () => {
+  it("renders nothing", () => {
+    render(<MarkdownHighlight isVisible={false} id="Highlight" />);
+
+    const highlightHelper = screen.queryByTestId("markdown-card--highlight");
+
+    expect(highlightHelper).not.toBeInTheDocument();
+    expect(highlightHelper).toBeNull();
+  });
+});

--- a/src/__tests__/MarkdownTogglableDetails.test.tsx
+++ b/src/__tests__/MarkdownTogglableDetails.test.tsx
@@ -38,3 +38,18 @@ describe("MarkdownTogglableDetails", () => {
     waitFor(() => expect(copyButton).toBeUndefined());
   });
 });
+
+ describe("MarkdownTogglableDetails isVisible is false", () => {
+   it("renders nothing", () => {
+     render(
+       <MarkdownTogglableDetails isVisible={false} id="Togglable details" />,
+     );
+
+     const detailsHelper = screen.queryByTestId(
+       "markdown-card--togglable-details",
+     );
+
+     expect(detailsHelper).not.toBeInTheDocument();
+     expect(detailsHelper).toBeNull();
+   });
+ });

--- a/src/app/cards/MarkdownCard.tsx
+++ b/src/app/cards/MarkdownCard.tsx
@@ -2,6 +2,7 @@ import { GitHubMarkdown } from "@/components/data/markdown";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import React from "react";
 import MarkdownTogglableDetails from "@/app/cards/MarkdownTogglableDetails";
+import MarkdownHighlight from "@/app/cards/MarkdownHighlight";
 
 export default function MarkdownCard(
   props: React.ComponentProps<"div"> & {
@@ -11,16 +12,21 @@ export default function MarkdownCard(
 ) {
   const { isVisible, query } = props;
   const { content, labels, title } = GitHubMarkdown;
+  const { highlight, toggleDetails } = content;
 
   const regexp = new RegExp(query, "gim");
 
-  const isTogglaDetailsMatch =
-    regexp.test(content.toggleDetails.snippet) ||
-    regexp.test(content.toggleDetails.title);
-
-  const isTogglaDetailsVisible =
+  const isSnippetVisible = (condition: boolean) =>
     (!query && isVisible) || // there are no active queries and the card is visible
-    (!!query && (regexp.test(title) || isTogglaDetailsMatch)); // active query that matches either card title or snippet title or content
+    (!!query && (regexp.test(title) || condition)); // active query that matches either card title or snippet title or content
+
+  const isTogglaDetailsVisible = isSnippetVisible(
+    regexp.test(toggleDetails.snippet) || regexp.test(toggleDetails.title),
+  );
+
+  const isHighlightVisible = isSnippetVisible(
+    regexp.test(highlight.snippet) || regexp.test(highlight.title),
+  );
 
   const isCardVisible = isVisible || (!!query && regexp.test(title));
 
@@ -41,7 +47,11 @@ export default function MarkdownCard(
       >
         <MarkdownTogglableDetails
           isVisible={isTogglaDetailsVisible}
-          id={content.toggleDetails.title}
+          id={toggleDetails.title}
+        />
+        <MarkdownHighlight
+          isVisible={isHighlightVisible}
+          id={highlight.title}
         />
       </CardContent>
     </Card>

--- a/src/app/cards/MarkdownCard.tsx
+++ b/src/app/cards/MarkdownCard.tsx
@@ -13,6 +13,7 @@ export default function MarkdownCard(
   const { isVisible, query } = props;
   const { content, labels, title } = GitHubMarkdown;
   const { highlight, toggleDetails } = content;
+  const { note, tip, important, warning, caution } = highlight.snippet;
 
   const regexp = new RegExp(query, "gim");
 
@@ -25,7 +26,12 @@ export default function MarkdownCard(
   );
 
   const isHighlightVisible = isSnippetVisible(
-    regexp.test(highlight.snippet) || regexp.test(highlight.title),
+    regexp.test(note) ||
+      regexp.test(tip) ||
+      regexp.test(important) ||
+      regexp.test(warning) ||
+      regexp.test(caution) ||
+      regexp.test(highlight.title),
   );
 
   const isCardVisible = isVisible || (!!query && regexp.test(title));

--- a/src/app/cards/MarkdownCard.tsx
+++ b/src/app/cards/MarkdownCard.tsx
@@ -47,10 +47,7 @@ export default function MarkdownCard(
         {/* <CardLabels labels={labels} /> */}
         <CardTitle className="text-4xl font-semibold">{title}</CardTitle>
       </CardHeader>
-      <CardContent
-        data-testid="markdown-card-content"
-        className="rounded-sm mt-3"
-      >
+      <CardContent data-testid="markdown-card-content" className="rounded-sm">
         <MarkdownTogglableDetails
           isVisible={isTogglaDetailsVisible}
           id={toggleDetails.title}

--- a/src/app/cards/MarkdownHighlight.tsx
+++ b/src/app/cards/MarkdownHighlight.tsx
@@ -13,8 +13,12 @@ export default function MarkdownHighlight({
 
   return isVisible ? (
     <>
-      <CardContent id={id} data-testid="markdown-card--highlight">
-        <CardHeader className="rounded-sm font-semibold text-xs">
+      <CardContent
+        id={id}
+        data-testid="markdown-card--highlight"
+        className="mt-5"
+      >
+        <CardHeader className="rounded-sm font-semibold text-xs text-sky-200">
           {highlight.title.toUpperCase()}
         </CardHeader>
         <CodeSnippet

--- a/src/app/cards/MarkdownHighlight.tsx
+++ b/src/app/cards/MarkdownHighlight.tsx
@@ -1,0 +1,26 @@
+import { GitHubMarkdown } from "@/components/data/markdown";
+import { CardContent, CardHeader, CodeSnippet } from "@/components/ui/card";
+
+export default function MarkdownHighlight({
+  id,
+  isVisible,
+}: {
+  id: string;
+  isVisible: boolean;
+}) {
+  const { highlight } = GitHubMarkdown.content;
+
+  return isVisible ? (
+    <>
+      <CardContent id={id} data-testid="markdown-card--highlight">
+        <CardHeader className="rounded-sm font-semibold text-xs">
+          {highlight.title.toUpperCase()}
+        </CardHeader>
+        <CodeSnippet
+          data-testid="markdown-highlight-code-snippet"
+          code={highlight.snippet}
+        />
+      </CardContent>
+    </>
+  ) : null;
+}

--- a/src/app/cards/MarkdownHighlight.tsx
+++ b/src/app/cards/MarkdownHighlight.tsx
@@ -9,6 +9,7 @@ export default function MarkdownHighlight({
   isVisible: boolean;
 }) {
   const { highlight } = GitHubMarkdown.content;
+  const { note, tip, important, warning, caution } = highlight.snippet;
 
   return isVisible ? (
     <>
@@ -18,7 +19,20 @@ export default function MarkdownHighlight({
         </CardHeader>
         <CodeSnippet
           data-testid="markdown-highlight-code-snippet"
-          code={highlight.snippet}
+          code={note}
+        />
+        <CodeSnippet data-testid="markdown-highlight-code-snippet" code={tip} />
+        <CodeSnippet
+          data-testid="markdown-highlight-code-snippet"
+          code={important}
+        />
+        <CodeSnippet
+          data-testid="markdown-highlight-code-snippet"
+          code={warning}
+        />
+        <CodeSnippet
+          data-testid="markdown-highlight-code-snippet"
+          code={caution}
         />
       </CardContent>
     </>

--- a/src/app/cards/MarkdownTogglableDetails.tsx
+++ b/src/app/cards/MarkdownTogglableDetails.tsx
@@ -11,8 +11,12 @@ export default function MarkdownTogglableDetails({
   const { toggleDetails } = GitHubMarkdown.content;
 
   return isVisible ? (
-    <CardContent id={id} data-testid="markdown-card--togglable-details">
-      <CardHeader className="rounded-sm font-semibold text-xs">
+    <CardContent
+      id={id}
+      data-testid="markdown-card--togglable-details"
+      className="mt-5"
+    >
+      <CardHeader className="rounded-sm font-semibold text-xs text-sky-200">
         {toggleDetails.title.toUpperCase()}
       </CardHeader>
       <CodeSnippet

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,7 +22,7 @@ export default function Home({
 
   return (
     <main className="min-h-screen bg-slate-100 pt-20 text-slate-900">
-      <div className="mx-auto flex max-w-4xl flex-col gap-12 px-6">
+      <div className="mx-auto flex max-w-4xl flex-col gap-12 px-6 mb-5">
         <div className="text-left">
           <h1 className="text-6xl text-slate-700 font-semibold">Taccuino</h1>
         </div>

--- a/src/components/data/markdown.ts
+++ b/src/components/data/markdown.ts
@@ -20,6 +20,23 @@ export const GitHubMarkdown = {
   </table>
 </details>`,
     },
+    highlight: {
+      title: "Highlight",
+      snippet: `> [!NOTE]  
+> Highlights information that users should take into account, even when skimming.
+
+> [!TIP]
+> Optional information to help a user be more successful.
+
+> [!IMPORTANT]  
+> Crucial information necessary for users to succeed.
+
+> [!WARNING]  
+> Critical content demanding immediate user attention due to potential risks.
+
+> [!CAUTION]
+> Negative potential consequences of an action.`,
+    },
   },
   labels: [
     {

--- a/src/components/data/markdown.ts
+++ b/src/components/data/markdown.ts
@@ -22,20 +22,18 @@ export const GitHubMarkdown = {
     },
     highlight: {
       title: "Highlight",
-      snippet: `> [!NOTE]  
-> Highlights information that users should take into account, even when skimming.
-
-> [!TIP]
-> Optional information to help a user be more successful.
-
-> [!IMPORTANT]  
-> Crucial information necessary for users to succeed.
-
-> [!WARNING]  
-> Critical content demanding immediate user attention due to potential risks.
-
-> [!CAUTION]
+      snippet: {
+        note: `> [!NOTE]  
+> Highlights information that users should take into account, even when skimming.`,
+        tip: `> [!TIP]
+> Optional information to help a user be more successful.`,
+        important: `> [!IMPORTANT]  
+> Crucial information necessary for users to succeed.`,
+        warning: `> [!WARNING]  
+> Critical content demanding immediate user attention due to potential risks.`,
+        caution: `> [!CAUTION]
 > Negative potential consequences of an action.`,
+      },
     },
   },
   labels: [

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -122,7 +122,7 @@ function CodeSnippet({
   return (
     <pre
       className={cn(
-        "code-snippet p-1.5 rounded-md font-mono text-sm bg-slate-300 text-slate-700 ml-1 mr-1",
+        "code-snippet p-1.5 rounded-md font-mono text-sm bg-slate-300 text-slate-700 ml-1 mr-1 mb-3",
         className,
       )}
       data-testid="code-snippet"


### PR DESCRIPTION
  <table>
    <tr>
      <th>In dev:</th>
      <td><img width="860" height="453" alt="image" src="https://github.com/user-attachments/assets/e9a15b11-cec7-428e-b4c1-988265b265f0" /></td>
    </tr>
    <tr>
      <th>In this branch:</th>
      <td><img width="867" height="823" alt="image" src="https://github.com/user-attachments/assets/949052d6-7848-4ed1-82cd-0c874337425a" /></td>
    </tr>
  </table>


Tests: [run nr. 59](https://github.com/nlusano/taccuino/actions/runs/17881127216/job/50848912269)

Test Suites: +1
Tests: +5